### PR TITLE
specify version floor for node engine required

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "10.13.0"
+    "node": ">=8.11.0"
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.1.0",


### PR DESCRIPTION
`8.11.0` for aws codebuild and `>=` for heroku which I had running at `10.13.0`